### PR TITLE
Add [[firstName]] placeholder

### DIFF
--- a/api/notifications.js
+++ b/api/notifications.js
@@ -68,7 +68,9 @@ const notifications = async (req, res) => {
         twilio.messages.create({
           to: student.phone,
           from: TWILIO_MESSAGING_SERVICE_SID,
-          body: message,
+          body: isPopulated(student.firstName)
+            ? message.replace('[[firstName]]', ` ${student.firstName}`)
+            : message,
         })
       }
       if (sendEmail && !validator.isEmpty(student.email)) {
@@ -76,7 +78,12 @@ const notifications = async (req, res) => {
           to: student.email,
           from: SENDGRID_FROM_EMAIL,
           templateId: SENDGRID_TEMPLATE_ID,
-          dynamicTemplateData: { subject, message },
+          dynamicTemplateData: {
+            subject,
+            message: isPopulated(student.firstName)
+              ? message.replace('[[firstName]]', ` ${student.firstName}`)
+              : message,
+          },
         }
         await sgMail.send(msg)
       }


### PR DESCRIPTION
It adds an extra space before the name as well so you can do "Hey[[firstName]]" and it'll either be "Hey" or "Hey Name."

This is kinda janky, could definitely use a better implementation later on. Don't have a lot of time rn tho.